### PR TITLE
Demonstrating the use of awaitility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,5 +49,10 @@
             <artifactId>guava</artifactId>
             <version>19.0</version>
         </dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>2.0.0</version>
+		</dependency>        
     </dependencies>
 </project>

--- a/src/test/java/com/evolutionnext/futures/CompletableFutureTest.java
+++ b/src/test/java/com/evolutionnext/futures/CompletableFutureTest.java
@@ -1,17 +1,15 @@
 package com.evolutionnext.futures;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.IllegalFormatException;
 import java.util.InputMismatchException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
+
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Test;
 
 public class CompletableFutureTest {
 
@@ -68,7 +66,7 @@ public class CompletableFutureTest {
     @Test
     public void completableFutureWithThenAccept() throws InterruptedException {
         integerFuture1.thenAccept(System.out::println);
-        Thread.sleep(5000);
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(integerFuture1::isDone);
     }
 
     @Test


### PR DESCRIPTION
Using google awaitility to improve the unit test readability by telling JUnit wait on the completion of a completablefuture.